### PR TITLE
Pin Docker `:latest` image tags to digest

### DIFF
--- a/jacoco-cli/Dockerfile
+++ b/jacoco-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:latest as builder
+FROM alpine:latest@sha256:958f4196fcbf9ef8afbef9884c934323f80e4592a12ca4919324881cc832f708 as builder
 RUN apk --no-cache add ca-certificates wget unzip
 RUN wget -O jacoco.zip http://search.maven.org/remotecontent?filepath=org/jacoco/jacoco/0.8.5/jacoco-0.8.5.zip && unzip jacoco.zip
 


### PR DESCRIPTION
The `:latest` tag changes, so future pulls of this image may retrieve a different image
with different (and possibly erroneous, unexpected, or dangerous) behavior.

Pin the image to an [image digest](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier)
for deterministic behavior.

*See also: [Hadolint error DL3007](https://github.com/hadolint/hadolint/wiki/DL3007).*

[_Created by Sourcegraph batch change `simonwaterer/pin-docker-images`._](https://sap-se.sourcegraphcloud.com/users/simonwaterer/batch-changes/pin-docker-images)